### PR TITLE
temporary update to adjust hours UTC for date inputs

### DIFF
--- a/client/src/components/PlantPlanningBlock/PlantPlanningBlock.js
+++ b/client/src/components/PlantPlanningBlock/PlantPlanningBlock.js
@@ -34,6 +34,7 @@ const PlantPlanningBlock = (data) => {
     let date = new Date();
     //one day in milliseconds
     const oneDay = 1000 * 60 * 60 * 24;
+    date.setUTCHours(date.getUTCHours() - 5); //daylight savings 5, else 6
     date.setDate(date.getDate());
     let newISODate = date.toISOString();
     let todaysDate = newISODate.split('T')[0];

--- a/client/src/components/WaterByLocation/WaterByLocation.js
+++ b/client/src/components/WaterByLocation/WaterByLocation.js
@@ -27,6 +27,7 @@ const WaterByLocation = (data) => {
 
     // set date variables
     let date = new Date();
+    date.setUTCHours(date.getUTCHours() - 5); //daylight savings 5, else 6
     date.setDate(date.getDate());
     let newISODate = date.toISOString();
     let todaysDate = newISODate.split('T')[0];


### PR DESCRIPTION
This temporarily resolves an issue where the date is incorrect for the date inputs as UTC is 5-6 hours ahead. This is only temporary because the hours have been manually entered as 5, which must change to 6 during the fall. Before then, will need to come up with another fix, or set up app to automatically check for daylight savings time.