### PR TITLE
Setting wateradhoc date to modify difference value

### DIFF
--- a/client/src/components/PlantDetails/PlantDetails.js
+++ b/client/src/components/PlantDetails/PlantDetails.js
@@ -244,6 +244,7 @@ function PlantDetails(p) {
             hardinessZoneMax: modPlant.hardinessZoneMax,
             lastPotted: modPlant.lastPotted,
             lastWatered: modPlant.lastWatered,
+            waterAdHoc: modPlant.waterAdHoc,
             waterRate: modPlant.waterRate,
             checkRate: modPlant.checkRate,
             propogating: modPlant.propogating,
@@ -924,6 +925,16 @@ function PlantDetails(p) {
                                                 name="lastWatered"
                                                 className="plant-details-specific"
                                                 onChange={handleInputChange}/>
+                                        </div>
+                                        <div className="plant-details-group">
+                                            <p className="plant-details-comment">Next Water Date</p>
+                                            <input 
+                                                type="date"
+                                                name="waterAdHoc"
+                                                className="plant-details-specific"
+                                                defaultValue={thisPlant.waterAdHoc ? thisPlant.waterAdHoc.split('T')[0] : null}
+                                                onChange={handleInputChange}
+                                            />
                                         </div>
                                         <p><b>All watering dates</b></p>
                                             <div className="">

--- a/client/src/components/PlantPlanningBlock/PlantPlanningBlock.js
+++ b/client/src/components/PlantPlanningBlock/PlantPlanningBlock.js
@@ -154,32 +154,23 @@ const PlantPlanningBlock = (data) => {
 
         indoor.forEach(plant => {
 
-            if(plant.lastWatered && plant.lastWatered.length > 1) {
+            if(plant.waterAdHoc || (plant.lastWatered && plant.lastWatered.length > 1)) {
 
                 //get the number of days since it was lastWatered
                 let daysAgo = getDifference(plant.lastWatered[plant.lastWatered.length - 1]);
                 let waterRate = plant.waterRate;
-                console.log("Watered this number of days ago: ", daysAgo);
+                console.log(plant.name + " watered this number of days ago: ", daysAgo);
                 plant["daysAgo"] = daysAgo;
-                // let daysAgoComparison = ;
-                // console.log("Watered this number of days ago COMPARISON conversion: ", daysAgoComparison)
-                //get the previous duration of watering the plant
-                //this will need to be updated to the last good duration for having watered the plant
-                //convert the lastWatered date you want to look at 
-                //
-                // plants.lastWatered && plants.lastWatered.length > 1 ? 
-                //() 
-                //- 
-                //Math.round((date.getTime() - new Date(plant.lastWatered[plant.lastWatered.length - 1]).getTime())/ oneDay)) + " days" : "n/a"
+
                 let lastDuration = getDifference(plant.lastWatered[plant.lastWatered.length - 2]) - getDifference(plant.lastWatered[plant.lastWatered.length - 1]);
                 console.log("Last Duration between waterings: ", lastDuration);
                 plant["duration"] = lastDuration;
 
-                //get the absolute date, as if doesn't matter if the difference is positive or negative
-                // let durationDifference = Math.abs(daysAgo - lastDuration);
-                let durationDifference = daysAgo - waterRate;
+                // if the waterAdHoc date exists to represent a skip date, use that to get the difference, otherwise, calculate between water rate and the last time it was watered
+                let durationDifference = plant.waterAdHoc ? getDifference(plant.waterAdHoc.split('T')[0]) : (daysAgo - waterRate);
+                
                 console.log(plant);
-                plant["difference"] = durationDifference
+                plant["difference"] = durationDifference;
                 console.log(plant);
 
                 if (durationDifference < 0) {

--- a/models/plant.js
+++ b/models/plant.js
@@ -37,7 +37,7 @@ const plantSchema = new Schema({
         type: Number
     },
     waterAdHoc: {
-        type: String
+        type: Date
     },
     sunlight: {
         type: Array


### PR DESCRIPTION
Setting the water ad hoc date for now will trigger logic that checks to see if this value exists when creating the difference value. Difference determines when we choose to water the plant. This is the initial step toward enabling a sort of "skip" in the case that watering the plant on a typical date will not work.