### PR TITLE
Updates to planning and details pages for various date handling adjustments

### DIFF
--- a/client/src/components/PlantDetails/PlantDetails.js
+++ b/client/src/components/PlantDetails/PlantDetails.js
@@ -324,6 +324,7 @@ function PlantDetails(p) {
             {
                 ids: [id],
                 lastWatered: newDate,
+                waterAdHoc: ""
             })
             .then(res => {
                 console.log("water date updated on plant details page", res)

--- a/client/src/utils/DateUtils.js
+++ b/client/src/utils/DateUtils.js
@@ -32,7 +32,7 @@ export function getDifference(waterDate, comparisonDate = date) {
     let differenceInDays = "";
 
     if(comparisonDate && waterDate) {
-        console.log(comparisonDate);
+        // console.log(comparisonDate);
         let dateDifference = comparisonDate.getTime() - parseWaterDate(waterDate).getTime();
         differenceInDays = Math.floor(dateDifference / oneDay);
         // console.log("differenceInDays is: ", differenceInDays);
@@ -58,6 +58,7 @@ export function getLocalDate(date) {
     if (date.getTimezoneOffset > 0 && isDST(date)) {
         date.setUTCHours(date.getUTCHours() - 5);
         date.setDate(date.getDate());
+        
     } else if (date.getTimezoneOffset > 0 && !isDST(date)) {
         date.setUTCHours(date.getUTCHours() - 6);
         date.setDate(date.getDate());
@@ -66,3 +67,36 @@ export function getLocalDate(date) {
     return date;
 
 } 
+
+
+export function getDayOfTheWeek(dayAsNumber) {
+
+    let yourDayofWeek = "";
+
+    switch (dayAsNumber) {
+        case 0:
+            yourDayofWeek = "Sunday";
+            break;
+        case 1:
+            yourDayofWeek = "Monday";
+            break;
+        case 2:
+            yourDayofWeek = "Tuesday";
+            break;
+        case 3:
+            yourDayofWeek = "Wednesday";
+            break;
+        case 4:
+            yourDayofWeek = "Thursday";
+            break;
+        case 5:
+            yourDayofWeek = "Friday";
+            break;
+        case 6:
+            yourDayofWeek = "Saturday";
+            break;
+        default:
+            yourDayofWeek = "None";
+        }
+        return yourDayofWeek;
+}

--- a/client/src/utils/DateUtils.js
+++ b/client/src/utils/DateUtils.js
@@ -7,6 +7,7 @@ let date = getLocalDate(new Date());
 let oneDay = 1000 * 60 * 60 * 24;
 
 //split the given date into day, month, and year, and output as new date object in string representation of the current date and time
+//Ex/Fri May 27 2022 00:00:00 GMT-0500 (Central Daylight Time)
 export function parseWaterDate(dateToParse) {
 
     let newWaterDate = ""
@@ -25,9 +26,26 @@ export function parseWaterDate(dateToParse) {
 
 }
 
+export function parseToYYYYMMDD(dateToParse) {
+
+    let newDate = "";
+
+    if (dateToParse) {
+
+        let dateToParseYear = dateToParse.getFullYear();
+        let dateToParseMonth = dateToParse.getMonth() + 1;
+        let dateToParseDay = dateToParse.getDate();
+
+        newDate = dateToParseYear + "-" + dateToParseMonth.toString().padStart(2, '0') + "-" + dateToParseDay.toString().padStart(2, '0');
+
+    }
+
+    return newDate;
+}
+
 //get number of milliseconds since epoch (getTime) to compare days in the same format, and determine difference in days
 //default comparison date to current day considering UTC, but can pass in other dates
-export function getDifference(waterDate, comparisonDate = date) {
+export function getDifferenceInDays(waterDate, comparisonDate = date) {
 
     let differenceInDays = "";
 
@@ -69,7 +87,7 @@ export function getLocalDate(date) {
 } 
 
 
-export function getDayOfTheWeek(dayAsNumber) {
+export function getLongDayOfTheWeek(dayAsNumber) {
 
     let yourDayofWeek = "";
 
@@ -95,8 +113,44 @@ export function getDayOfTheWeek(dayAsNumber) {
         case 6:
             yourDayofWeek = "Saturday";
             break;
+        case 7:
+            yourDayofWeek = "Sunday";
+            break;
         default:
             yourDayofWeek = "None";
+        }
+        return yourDayofWeek;
+}
+
+
+export function getNumberDayOfWeek(dayAsLongString) {
+
+    let yourDayofWeek = "";
+
+    switch (dayAsLongString) {
+        case "Sunday":
+            yourDayofWeek = 0;
+            break;
+        case "Monday":
+            yourDayofWeek = 1;
+            break;
+        case "Tuesday":
+            yourDayofWeek = 2;
+            break;
+        case "Wednesday":
+            yourDayofWeek = 3;
+            break;
+        case "Thursday":
+            yourDayofWeek = 4;
+            break;
+        case "Friday":
+            yourDayofWeek = 5;
+            break;
+        case "Saturday":
+            yourDayofWeek = 6;
+            break;
+        default:
+            yourDayofWeek = null;
         }
         return yourDayofWeek;
 }

--- a/routes/plants.js
+++ b/routes/plants.js
@@ -109,7 +109,8 @@ router.post("/plants/watering", (req, res) => {
         }
       }, 
         {
-          $addToSet: { "lastWatered": req.body.lastWatered}
+          $addToSet: { "lastWatered": req.body.lastWatered},
+          $set: { waterAdHoc: req.body.waterAdHoc }
         }
     )
   .then(updated => {


### PR DESCRIPTION
This pull request includes date handling for:
- adding a next water date to plant details that functions as a way to skip the existing scheduled difference
- trimmed logic for sorting on columns and pushing to ready, upcoming, later and other plant groups
- handling for which plants to show based on proximity to upcoming scheduled dates
- date utils updates to facilitate planning page updates